### PR TITLE
Unpin scipy version (and mpmath version)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,7 +11,7 @@ maintainers = [
 ]
 requires-python = ">=3.11"
 dependencies = [
-	     "mpmath==1.3.0",
+	     "mpmath",
 	     "numpy",
 	     "packaging",
 	     "polars",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,7 +16,7 @@ dependencies = [
 	     "packaging",
 	     "polars",
 	     "pyarrow",
-	     "scipy==1.15.2",
+	     "scipy"
 ]
 readme = "README.md"
 

--- a/src/xsref/_reference/_framework.py
+++ b/src/xsref/_reference/_framework.py
@@ -17,13 +17,6 @@ from typing import overload
 __all__ = ["reference_implementation", "XSRefFallbackWarning"]
 
 
-if version.parse(scipy.__version__) >= version.parse("1.16"):
-    raise RuntimeError(
-        f"SciPy {scipy.__version__} is not an independent reference. SciPy"
-        " depends on xsf as of version 1.16."
-    )
-
-
 def get_signature_from_type_hints(type_hints):
     input_types = []
     for key, val in type_hints.items():


### PR DESCRIPTION
This PR unpins SciPy, which was set at the oldest version prior to SciPy depending on `xsf` in order to remain an independent reference. I was planning to remove SciPy as a dependency entirely, but I now think that isn't actually desirable; it's still useful for generating reference tolerances and checking consistency with the `mpmath` implementations. I do plan to stop using it as a fallback though, and think we can fill in the remaining gaps in reference implementations with the free for open source use Wolfram engine. This PR should unblock https://github.com/scipy/xsf/pull/175. I've also unpinned the `mpmath` version. I think I had planned to manually check things out before each `mpmath` update to guard against regressions, but I don't have bandwidth for that.